### PR TITLE
Fix undeclared property reference error in yearbook

### DIFF
--- a/example44_MPDFI_yearbook.php
+++ b/example44_MPDFI_yearbook.php
@@ -165,9 +165,6 @@ function SinglePage(Mpdf\Mpdf $mpdf, $html, $pw, $ph, $minK = 1, $inc = 0.1)
 			if (isset($mpdf->PageAnnots[$mpdf->page])) {
 				unset($mpdf->PageAnnots[$mpdf->page]);
 			}
-			if (isset($mpdf->ktBlock[$mpdf->page])) {
-				unset($mpdf->ktBlock[$mpdf->page]);
-			}
 			if (isset($mpdf->PageLinks[$mpdf->page])) {
 				unset($mpdf->PageLinks[$mpdf->page]);
 			}


### PR DESCRIPTION
There's no property called `ktBlock` in the library. I tried to search for properties with a similar name, but couldn't locate a match.