### PR TITLE
Fix undeclared property reference error for booklet

### DIFF
--- a/example43_MPDFI_booklet.php
+++ b/example43_MPDFI_booklet.php
@@ -47,7 +47,7 @@ $mpdf = new \Mpdf\Mpdf([
 
 $mpdf->mirrorMargins = 1;
 $mpdf->SetDisplayMode('fullpage','two');
-$mpdf->useOnlyCoreFonts = true;
+$mpdf->onlyCoreFonts = true;
 $mpdf->defaultfooterfontsize = 13;
 $mpdf->AddPage();
 $mpdf->Image('assets/clematis.jpg',0,0,210,297,'jpg','',true, false);	// e.g. the last "false" allows a full page picture


### PR DESCRIPTION
The actual property is `onlyCoreFonts`, but since the `c` mode is being used this isn't necessary.